### PR TITLE
Minor improvements to date parsing

### DIFF
--- a/table.js
+++ b/table.js
@@ -42,7 +42,7 @@ class Table {
     
 };
 
-function string_to_date(x) {return new Date(x)}
+function string_to_date(x) {return moment(x).toDate()}
 
 function string_to_int(x) {return parseInt(x)}
 


### PR DESCRIPTION
On Safari the format used by the Italian dataset cannot be parsed by the `Date` constructor (`new Date('2020-02-24 18:00:00')` results in an `Invalid Date`).

~~Additionally, the parsing of the "anglo" format can be simplified thanks to moment.~~