### PR TITLE
Aggiunto casi_testati e statistiche derivate

### DIFF
--- a/dataset_dpc.js
+++ b/dataset_dpc.js
@@ -16,6 +16,7 @@ class DpcDataset extends BaseDataset {
             "deceduti",
             "totale_casi",
             "tamponi",
+            "casi_testati",
 
             // computed fields:
             "incremento deceduti",
@@ -27,6 +28,7 @@ class DpcDataset extends BaseDataset {
             "incremento dimessi_guariti",
             "incremento totale_casi",
             "incremento tamponi",
+            "incremento casi_testati",
 
             "ricoverati_con_sintomi / totale_casi",
             "terapia_intensiva / totale_casi",
@@ -38,6 +40,7 @@ class DpcDataset extends BaseDataset {
             "deceduti / totale_casi",
 
             "totale_casi / tamponi",
+            "totale_casi / casi_testati",
             "tamponi / popolazione",
 
             "totale_casi / popolazione",
@@ -49,6 +52,7 @@ class DpcDataset extends BaseDataset {
             "nuovi_positivi / popolazione",
             "dimessi_guariti / popolazione",
             "deceduti / popolazione",
+            "nuovi_positivi / incremento casi_testati",
             "nuovi_positivi / incremento tamponi",
         ];
         this.filter_column = options.filter_column || null;


### PR DESCRIPTION
Ho aggiunto il numero dei casi testati più alcuni valori derivati (incremento, casi rilevati su testati, nuovi casi su incremento testati) che sono particolarmente interessanti e non erano presenti inizialmente nei dati della Prot. Civ.