### PR TITLE
Aggiunto ingressi terapia intensiva

### DIFF
--- a/dataset_dpc.js
+++ b/dataset_dpc.js
@@ -8,6 +8,7 @@ class DpcDataset extends BaseDataset {
         this.fields = [
             "ricoverati_con_sintomi",
             "terapia_intensiva",
+            "ingressi_terapia_intensiva",
             "totale_ospedalizzati",
             "isolamento_domiciliare",
             "totale_positivi",


### PR DESCRIPTION
Ho aggiunto gli ingressi in terapia intensiva. Hanno cominciato a fornire il dato il 9/12, stando al [changelog](https://github.com/pcm-dpc/COVID-19/blob/master/CHANGELOG.md).